### PR TITLE
Get tests to work using graphql-tag

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'cypress'
+// import webpackPreprocessor from '@cypress/webpack-preprocessor'
+// If you add webpack, import it here
+// import webpackConfig from './webpack.config'
 
 export default defineConfig({
   e2e: {
@@ -16,5 +19,17 @@ export default defineConfig({
     // downloadsFolder: 'cypress/e2e/downloads',
     // screenshotsFolder: 'cypress/e2e/screenshots',
     // videosFolder: 'cypress/e2e/videos',
+
+    setupNodeEvents(on, config) {
+      const options = {
+        // TODO: webpack config that understands `#import` and `.graphql`.
+        // webpackOptions: webpackConfig,
+      }
+
+      // Apply preprocessor to cypress/* files, and all spec files.
+      // on('file:preprocessor', webpackPreprocessor(options))
+
+      return config
+    },
   },
 })

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-graphql": "^4.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.7.1",
+    "graphql-tag": "^2.12.6",
     "prettier": "^2.7.1",
     "sass": "^1.53.0",
     "sass-loader": "^13.0.0",

--- a/src/modules/countries/graphql/fragments/country.ts
+++ b/src/modules/countries/graphql/fragments/country.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag'
+
+export const countries = gql`
+  fragment CountryFragment on Country {
+    code
+    name
+    phone
+    currency
+    languages {
+      code
+      name
+      native
+    }
+  }
+`

--- a/src/modules/countries/graphql/queries/getCountries.ts
+++ b/src/modules/countries/graphql/queries/getCountries.ts
@@ -1,0 +1,22 @@
+// #import "../fragments/country.fragment.gql"
+import gql from 'graphql-tag'
+
+export const getCountries = gql`
+  query GetCountries {
+    countries {
+      ...CountryFragment
+    }
+  }
+
+  fragment CountryFragment on Country {
+    code
+    name
+    phone
+    currency
+    languages {
+      code
+      name
+      native
+    }
+  }
+`

--- a/src/modules/countries/graphql/queries/getCountries.ts
+++ b/src/modules/countries/graphql/queries/getCountries.ts
@@ -1,22 +1,13 @@
 // #import "../fragments/country.fragment.gql"
 import gql from 'graphql-tag'
+import { countries } from '../fragments/country'
 
 export const getCountries = gql`
+  ${ countries }
+
   query GetCountries {
     countries {
       ...CountryFragment
-    }
-  }
-
-  fragment CountryFragment on Country {
-    code
-    name
-    phone
-    currency
-    languages {
-      code
-      name
-      native
     }
   }
 `

--- a/src/modules/countries/tests/e2e/countries.spec.ts
+++ b/src/modules/countries/tests/e2e/countries.spec.ts
@@ -1,4 +1,6 @@
-import getCountries from '../../graphql/queries/getCountries.gql'
+import { getCountries } from '../../graphql/queries/getCountries'
+// Could not get this working.
+// #import GetCountries from '../../graphql/queries/getCountries.gql'
 
 it('should see list of countries', () => {
   cy.log('Working test')
@@ -13,7 +15,6 @@ it('should see list of countries', () => {
 
   // check that Request been made
   cy.wait('@queryGetCountries').then(({ response }) => {
-    // @ts-expect-error undefined variable
     expect(response.body.data.countries).to.exist
   })
 
@@ -25,13 +26,35 @@ it('should see list of countries', () => {
   cy.getDataTableBodyLength(4)
 })
 
-it('test with using gql query', () => {
+// TODO: configure webpack to understand `#import`.
+it.skip('test with using gql query', () => {
   cy.request({
     log: true,
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
     url: 'https://countries.trevorblades.com/',
     body: JSON.stringify({
-      query: getCountries,
+      // @ts-ignore
+      query: GetCountries
+    }),
+  }).then(({ body: { data } }) => {
+    cy.log(data)
+  })
+})
+
+it('test with using gql query with graphql-tag', () => {
+  cy.request({
+    log: true,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    url: 'https://countries.trevorblades.com/',
+    body: JSON.stringify({
+      // get as string.
+      query: getCountries?.loc?.source.body
     }),
   }).then(({ body: { data } }) => {
     cy.log(data)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2022",
+    "target": "es2019",
     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ESNext", "DOM"],
+    "lib": ["es2019", "DOM"],
     /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -26,7 +26,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "ESNext",
+    "module": "commonjs",
     "resolveJsonModule": true,
     "isolatedModules": false,
     /* Specify what module code is generated. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,20 +34,12 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    include: ['@apollo/client/core'],
+    include: [
+      '@apollo/client/core', 
+      '@apollo/client/link/error',
+      'vuetify/lib/components/VCard/index.mjs',
+      'vuetify/lib/components/VTable/index.mjs'
+    ],
     exclude: ['@apollo/client'],
   },
-  /* remove the need to specify .vue files https://vitejs.dev/config/#resolve-extensions
-  resolve: {
-    extensions: [
-      '.js',
-      '.json',
-      '.jsx',
-      '.mjs',
-      '.ts',
-      '.tsx',
-      '.vue',
-    ]
-  },
-  */
 })


### PR DESCRIPTION
This PR is a response to [this issue](https://github.com/cypress-io/cypress/issues/22519).

I changed some code to show you could run your tests. I could not get it working with the `#import` syntax - this seems to be an Apollo specific thing that doesn't work outside of `useQuery`, I'm not sure why. I'd recommend the `gql` tag anyway, this also seems to be what Apollo generally recommends? [Docs](https://www.apollographql.com/docs/react/data/fragments/).

I was having some flake with Vite's optimization, so I tried adding some entries to `optimize`. I think this is due to the Vuetify "auto import" plugin. I'm not sure how we can handle this sort of thing in Cypress, yet, but I'll think about it. Once the optimization runs, it seems okay. We basically do test-only pre-optimization at Cypress, see [here](https://github.com/cypress-io/cypress/blob/develop/packages/app/cypress.config.ts#L28-L40). Edit: looks like Vite 3 might help with this: https://twitter.com/patak_dev/status/1541776555688484864?s=20&t=n4ylWNG6PYQr2e3rIW_cYw

Some suggestions:

- add your components as you need them to the optimization.
- instead of testing against your dev server, build the final website and test against that. It'll be more reflective of what real users encounter, and there won't be any optimization flake, since it's all built.